### PR TITLE
feat: enable multi-architecture Docker builds (amd64 + arm64)

### DIFF
--- a/.github/workflows/build-release-docker-hub.yml
+++ b/.github/workflows/build-release-docker-hub.yml
@@ -54,7 +54,7 @@ jobs:
         with:
           context: .
           file: ./Dockerfile
-          platforms: linux/amd64
+          platforms: linux/amd64,linux/arm64
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.prep.outputs.tags }}
           labels: |


### PR DESCRIPTION
## Summary
- Enable multi-architecture Docker image builds for linux/amd64 and linux/arm64
- Updated `.github/workflows/build-release-docker-hub.yml` to build for both platforms

## Notes
- QEMU and Docker Buildx were already configured, just needed to add arm64 to platforms
- Dockerfile already uses `${TARGETARCH}` for Hugo binary download, so it's ready for multi-arch

## Test plan
- [ ] Verify GitHub Actions workflow runs successfully
- [ ] Verify multi-arch manifest is created on Docker Hub
- [ ] Test image pull and run on both amd64 and arm64 machines

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Docker images now support ARM64 architecture in addition to AMD64, enabling compatibility with ARM-based systems.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->